### PR TITLE
fix packaging instructions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,5 @@ upgrade = true
 # https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["indexer*"]
-exclude = ["indexer.tests*"]
+include = ["sous_chef_kitchen*"]
 namespaces = false


### PR DESCRIPTION
The package name this exports is wrong -- probably just a copy paste error. We need to fix this in order to use this code in other places via pip and such.